### PR TITLE
Seachbar post

### DIFF
--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -15,7 +15,7 @@ describe('/search-preferences spc', () => {
   it('loads the SearchPreferenceForm component on the page', () => {
     cy.visit('http://localhost:3000/search-preferences?locations=hackney');
     cy.get('[data-cy="SearchPreferencesForm"]').should('be.visible');
-    cy.get('button').click
+    cy.get('form').submit()
     cy.url().should('include', '&billsIncluded=');
   });
 });

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -4,9 +4,18 @@ describe('/ page spec', () => {
   });
 });
 
-describe('/listings page spec', ()=> {
-  it('loads listings available', ()=>{
+describe('/listings page spec', () => {
+  it('loads listings available', () => {
     cy.visit('http://localhost:3000/listings');
     cy.get('.test-class-property').should('be.visible');
-  })
-})
+  });
+});
+
+describe('/search-preferences spc', () => {
+  it('loads the SearchPreferenceForm component on the page', () => {
+    cy.visit('http://localhost:3000/search-preferences?locations=hackney');
+    cy.get('[data-cy="SearchPreferencesForm"]').should('be.visible');
+    cy.get('button').click
+    cy.url().should('include', '&billsIncluded=');
+  });
+});

--- a/src/app/log-in/components/LogInForm.tsx
+++ b/src/app/log-in/components/LogInForm.tsx
@@ -14,7 +14,7 @@ export default function SignInForm() {
             </div>
             <TextInput
               id="email1"
-              placeholder="name@flowbite.com"
+              placeholder="name@email.com"
               required
               shadow
               type="email"

--- a/src/app/search-preferences/page.tsx
+++ b/src/app/search-preferences/page.tsx
@@ -20,8 +20,13 @@ const preferences = {
     'bike storage',
     'garden',
     'fireplace',
+    'elevator',
+    'wheelchair accessible',
+    'electric heating',
+    'gas heating',
+    'visitor parking'
   ],
-  parking: ['allocated parking', 'no parking', 'exterior parking'],
+  parking: ['allocated', 'no parking', 'exterior parking'],
 };
 
 export default function SearchPreferences() {

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import { useState, useEffect, FormEventHandler } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
 import { initializeSearch } from 'utils/mapHelper';
 import { convertAddress } from 'utils/mapHelper';
-import { ILocation } from '../../types/types';
 
 const SearchBar = () => {
   const router = useRouter();
@@ -23,7 +22,7 @@ const SearchBar = () => {
     e.preventDefault();
     const value: any = e.nativeEvent?.target;
     if (!value) return;
-    const address = value[0].value;
+    const address = value.area.value;
     let { lat, lng } = await convertAddress(address);
     router.push('/listings?lat=' + lat + '&lng=' + lng);
   };
@@ -60,6 +59,7 @@ const SearchBar = () => {
           placeholder="Location..."
           required
           value={inputValue}
+          name='area'
           onChange={(e) => setInputValue(e.target.value)}
         />
         <button

--- a/src/components/SearchPreferencesForm.tsx
+++ b/src/components/SearchPreferencesForm.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import { useRouter } from 'next/navigation';
 import {
   Button,
   Checkbox,
@@ -9,14 +10,65 @@ import {
   ToggleSwitch,
   Card,
 } from 'flowbite-react';
-import { SearchFormProps } from '../../types/types';
+
+import { SearchFormProps, SearchPreferenceProps } from '../../types/types';
+import { convertAddress } from 'utils/mapHelper';
 
 const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
+  const router = useRouter();
+
+  const redirect = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const submitted: any = e.nativeEvent?.target;
+    if (!submitted) return;
+
+    const search: SearchPreferenceProps = {
+      preferences: {
+        location: submitted.location.value,
+        cost: {
+          max: submitted.localtion.value,
+          billsIncluded: submitted.bills.value,
+        },
+        propertyDetails: {
+          type: submitted.type.value,
+          rooms: {
+            min: submitted.roomsMin.value,
+            max: submitted.roomsMax.value,
+          },
+          tenancyMin: submitted.tenancy.value,
+        },
+        features: {
+          pets: submitted.pets.value,
+          smokers: submitted.smokers.value,
+          bike_storage: submitted.bike_storage.value,
+          garden: submitted.garden.value,
+          fireplace: submitted.fireplace.value,
+          elevator: submitted.elevator.value,
+          wheelchair_accessible: submitted.wheelchair_accessible.value,
+          electric_heating: submitted.electric_heating.value,
+          gas_heating: submitted.gas_heating.value,
+          visitor_parking: submitted.visitor_parking.value,
+          parking: {
+            allocated: submitted.allocated.value,
+            street: submitted.street.value,
+          },
+        },
+      },
+    };
+
+    const {lat, lng} = await convertAddress(search.preferences.location)
+
+    router.push(`/listings?=${lat && 'lat='+lat}${lng && 'lng='+lng}`)
+
+  };
+
+
   return (
     <Card className="w-8/12 p-4 m-auto">
       <form
         action="/listings"
         className="flex max-w-md flex-col mx-20 my-8 gap-4"
+        onSubmit={redirect}
       >
         <fieldset className="mt-4">
           <legend>Location</legend>
@@ -45,11 +97,13 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
               id="default-range"
               max={preferences.cost.max}
               min={preferences.cost.min}
+              name="cost"
             />
           </div>
           <ToggleSwitch
             checked
             label="Bills included only"
+            name="bills"
             onChange={() => {
               console.log('FILTER FOR BILLS INCLUDED');
             }}
@@ -63,7 +117,7 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
               <div className="mb-2 block">
                 <Label htmlFor="roomsMin" value="Min" />
               </div>
-              <Select id="roomsMin" required>
+              <Select id="roomsMin" name="roomsMin" required>
                 {preferences.propertyDetails.rooms.map((number) => {
                   return <option key={`${number}-rooms`}>{number}</option>;
                 })}
@@ -73,7 +127,7 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
               <div className="mb-2 block">
                 <Label htmlFor="roomsMax" value="Max" />
               </div>
-              <Select id="roomsMax" required>
+              <Select id="roomsMax" name="roomsMax" required>
                 {preferences.propertyDetails.rooms.map((number) => {
                   return <option key={`${number}-rooms`}>{number}</option>;
                 })}
@@ -84,7 +138,7 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
             <div className="mb-2 block">
               <Label htmlFor="tenancyMin" value="Minimum Tenancy" />
             </div>
-            <Select id="tenancyMin" required>
+            <Select id="tenancyMin" name="tenancy" required>
               {preferences.propertyDetails.tenancyMin.map((duration) => {
                 return <option key={`${duration}-duration`}>{duration}</option>;
               })}
@@ -99,7 +153,7 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
                   key={`${typeValue}-type`}
                   className="flex-col items-center space-x-2"
                 >
-                  <Checkbox id={typeValue} name={typeValue} value={typeValue} />
+                  <Checkbox id={typeValue} name="type" value={typeValue} />
                   <Label>{type}</Label>
                 </div>
               );

--- a/src/components/SearchPreferencesForm.tsx
+++ b/src/components/SearchPreferencesForm.tsx
@@ -28,7 +28,7 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
   };
 
   return (
-    <Card data-cy='searchPreferencesForm' className="w-8/12 p-4 m-auto">
+    <Card data-cy='SearchPreferencesForm' className="w-8/12 p-4 m-auto">
       <form
         action="/listings"
         className="flex max-w-md flex-col mx-20 my-8 gap-4"

--- a/src/components/SearchPreferencesForm.tsx
+++ b/src/components/SearchPreferencesForm.tsx
@@ -28,7 +28,7 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
   };
 
   return (
-    <Card className="w-8/12 p-4 m-auto">
+    <Card data-cy='searchPreferencesForm' className="w-8/12 p-4 m-auto">
       <form
         action="/listings"
         className="flex max-w-md flex-col mx-20 my-8 gap-4"

--- a/src/components/SearchPreferencesForm.tsx
+++ b/src/components/SearchPreferencesForm.tsx
@@ -11,8 +11,8 @@ import {
   Card,
 } from 'flowbite-react';
 
-import { SearchFormProps, SearchPreferenceProps } from '../../types/types';
-import { convertAddress } from 'utils/mapHelper';
+import { SearchFormProps } from '../../types/types';
+import { makeIntoQuery, makeIntoProps } from 'utils/searchPreferenceHelpers';
 
 const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
   const router = useRouter();
@@ -22,55 +22,8 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
 
   const redirect = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const submitted: any = e.nativeEvent?.target;
-    if (!submitted) return;
-
-    const search: SearchPreferenceProps = {
-      preferences: {
-        location: submitted.location.value,
-        cost: {
-          max: submitted.cost.value,
-          billsIncluded: submitted.bills.checked,
-        },
-        propertyDetails: {
-          type: submitted.type.value,
-          rooms: {
-            min: submitted.roomsMin.value,
-            max: submitted.roomsMax.value,
-          },
-          tenancyMin: submitted.tenancy.value,
-        },
-        features: {
-          pets: submitted.pets_allowed.checked,
-          smokers: submitted.smokers_allowed.checked,
-          bike_storage: submitted.bike_storage.checked,
-          garden: submitted.garden.checked,
-          fireplace: submitted.fireplace.checked,
-          elevator: submitted.elevator.checked,
-          wheelchair_accessible: submitted.wheelchair_accessible.checked,
-          electric_heating: submitted.electric_heating.checked,
-          gas_heating: submitted.gas_heating.checked,
-          visitor_parking: submitted.visitor_parking.checked,
-          parking: {
-            allocated: submitted.allocated.checked,
-            exterior_parking: submitted.exterior_parking.checked,
-          },
-        },
-      },
-    };
-
-    const { lat, lng } = await convertAddress(search.preferences.location);
-    
-    const makeIntoQuery = (data: object) => {
-      return Object.keys(data).map(key=>{
-        let value = data[key]
-        if (value !== null && typeof value === 'object') value = makeIntoQuery(value)
-        return `${key}=${encodeURIComponent(`${value}`)}`
-      }).join('&')
-    }
-
+    const search = makeIntoProps(e.nativeEvent?.target) 
     const query = makeIntoQuery(search.preferences)
-
     router.push(`/listings?=${query}`);
   };
 

--- a/src/components/SearchPreferencesForm.tsx
+++ b/src/components/SearchPreferencesForm.tsx
@@ -56,12 +56,10 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
       },
     };
 
-    const {lat, lng} = await convertAddress(search.preferences.location)
+    const { lat, lng } = await convertAddress(search.preferences.location);
 
-    router.push(`/listings?=${lat && 'lat='+lat}${lng && 'lng='+lng}`)
-
+    router.push(`/listings?=${lat && 'lat=' + lat}${lng && 'lng=' + lng}`);
   };
-
 
   return (
     <Card className="w-8/12 p-4 m-auto">

--- a/src/components/SearchPreferencesForm.tsx
+++ b/src/components/SearchPreferencesForm.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   Button,
@@ -16,18 +16,21 @@ import { convertAddress } from 'utils/mapHelper';
 
 const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
   const router = useRouter();
+  const [maxRent, setMaxRent] = useState<number>(preferences.cost.max - preferences.cost.min)
 
   const redirect = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const submitted: any = e.nativeEvent?.target;
-    if (!submitted) return;
+    const test = submitted
+    console.log({test})
+    if (!submitted) return console.log('💩');
 
     const search: SearchPreferenceProps = {
       preferences: {
         location: submitted.location.value,
         cost: {
-          max: submitted.localtion.value,
-          billsIncluded: submitted.bills.value,
+          max: submitted.cost.value,
+          billsIncluded: submitted.bills.checked,
         },
         propertyDetails: {
           type: submitted.type.value,
@@ -38,27 +41,31 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
           tenancyMin: submitted.tenancy.value,
         },
         features: {
-          pets: submitted.pets.value,
-          smokers: submitted.smokers.value,
-          bike_storage: submitted.bike_storage.value,
-          garden: submitted.garden.value,
-          fireplace: submitted.fireplace.value,
-          elevator: submitted.elevator.value,
-          wheelchair_accessible: submitted.wheelchair_accessible.value,
-          electric_heating: submitted.electric_heating.value,
-          gas_heating: submitted.gas_heating.value,
-          visitor_parking: submitted.visitor_parking.value,
+          pets: submitted.pets_allowed.checked,
+          smokers: submitted.smokers_allowed.checked,
+          bike_storage: submitted.bike_storage.checked,
+          garden: submitted.garden.checked,
+          fireplace: submitted.fireplace.checked,
+          elevator: submitted.elevator.checked,
+          wheelchair_accessible: submitted.wheelchair_accessible.checked,
+          electric_heating: submitted.electric_heating.checked,
+          gas_heating: submitted.gas_heating.checked,
+          visitor_parking: submitted.visitor_parking.checked,
           parking: {
-            allocated: submitted.allocated.value,
-            street: submitted.street.value,
+            allocated: submitted.allocated.checked,
+            street: submitted.street.checked,
           },
         },
       },
     };
 
-    const { lat, lng } = await convertAddress(search.preferences.location);
+    // const { lat, lng } = await convertAddress(search.preferences.location);
 
-    router.push(`/listings?=${lat && 'lat=' + lat}${lng && 'lng=' + lng}`);
+    const query = Object.keys(submitted).map(key=>{
+      `${key}=${key.valueOf}`
+    }).join('&')
+    console.log(query)
+    router.push(`/listings?=${query}`);
   };
 
   return (
@@ -80,7 +87,7 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
               required
               type="text"
               name="location"
-              defaultValue={preferences.location && preferences.location}
+              defaultValue={preferences.location}
             />
           </div>
         </fieldset>
@@ -89,13 +96,15 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
           <legend>Cost</legend>
           <div>
             <div className="mb-1 block">
-              <Label htmlFor="default-range" value="Maximum Rent" />
+              <Label htmlFor="default-range" value={`Maximum Rent: ${maxRent}`} />
             </div>
             <RangeSlider
               id="default-range"
               max={preferences.cost.max}
               min={preferences.cost.min}
               name="cost"
+              defaultValue={preferences.cost.max - preferences.cost.min}
+              onChange={(e)=>{setMaxRent(Number(e.target.value))}}
             />
           </div>
           <ToggleSwitch
@@ -117,7 +126,7 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
               </div>
               <Select id="roomsMin" name="roomsMin" required>
                 {preferences.propertyDetails.rooms.map((number) => {
-                  return <option key={`${number}-rooms`}>{number}</option>;
+                  return <option key={`${number}-rooms`} value={number}>{number}</option>;
                 })}
               </Select>
             </div>
@@ -127,7 +136,7 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
               </div>
               <Select id="roomsMax" name="roomsMax" required>
                 {preferences.propertyDetails.rooms.map((number) => {
-                  return <option key={`${number}-rooms`}>{number}</option>;
+                  return <option key={`${number}-rooms`} value={number}>{number}</option>;
                 })}
               </Select>
             </div>
@@ -138,14 +147,14 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
             </div>
             <Select id="tenancyMin" name="tenancy" required>
               {preferences.propertyDetails.tenancyMin.map((duration) => {
-                return <option key={`${duration}-duration`}>{duration}</option>;
+                return <option key={`${duration}-duration`} value={duration}>{duration}</option>;
               })}
             </Select>
           </div>
 
           <div className="flex-row space-y-2 mt-4">
             {preferences.propertyDetails.type.map((type) => {
-              const typeValue = type.replace(' ', '-');
+              const typeValue = type.replace(' ', '_');
               return (
                 <div
                   key={`${typeValue}-type`}
@@ -163,7 +172,7 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
           <legend>Features</legend>
           <div className="flex-row space-y-2 mt-4">
             {preferences.features.map((feature) => {
-              const featureValue = feature.replace(' ', '-');
+              const featureValue = feature.replace(' ', '_');
               return (
                 <div
                   key={`${featureValue}-feature`}
@@ -183,7 +192,7 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
         <fieldset>
           <legend>Parking</legend>
           {preferences.parking.map((option) => {
-            const optionValue = option.replace(' ', '-');
+            const optionValue = option.replace(' ', '_');
             return (
               <div
                 key={`${optionValue}-feature`}

--- a/src/components/SearchPreferencesForm.tsx
+++ b/src/components/SearchPreferencesForm.tsx
@@ -16,14 +16,14 @@ import { convertAddress } from 'utils/mapHelper';
 
 const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
   const router = useRouter();
-  const [maxRent, setMaxRent] = useState<number>(preferences.cost.max - preferences.cost.min)
+  const [maxRent, setMaxRent] = useState<number>(
+    preferences.cost.max - preferences.cost.min,
+  );
 
   const redirect = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const submitted: any = e.nativeEvent?.target;
-    const test = submitted
-    console.log({test})
-    if (!submitted) return console.log('💩');
+    if (!submitted) return;
 
     const search: SearchPreferenceProps = {
       preferences: {
@@ -53,18 +53,24 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
           visitor_parking: submitted.visitor_parking.checked,
           parking: {
             allocated: submitted.allocated.checked,
-            street: submitted.street.checked,
+            exterior_parking: submitted.exterior_parking.checked,
           },
         },
       },
     };
 
-    // const { lat, lng } = await convertAddress(search.preferences.location);
+    const { lat, lng } = await convertAddress(search.preferences.location);
+    
+    const makeIntoQuery = (data: object) => {
+      return Object.keys(data).map(key=>{
+        let value = data[key]
+        if (value !== null && typeof value === 'object') value = makeIntoQuery(value)
+        return `${key}=${encodeURIComponent(`${value}`)}`
+      }).join('&')
+    }
 
-    const query = Object.keys(submitted).map(key=>{
-      `${key}=${key.valueOf}`
-    }).join('&')
-    console.log(query)
+    const query = makeIntoQuery(search.preferences)
+
     router.push(`/listings?=${query}`);
   };
 
@@ -96,7 +102,10 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
           <legend>Cost</legend>
           <div>
             <div className="mb-1 block">
-              <Label htmlFor="default-range" value={`Maximum Rent: ${maxRent}`} />
+              <Label
+                htmlFor="default-range"
+                value={`Maximum Rent: ${maxRent}`}
+              />
             </div>
             <RangeSlider
               id="default-range"
@@ -104,7 +113,9 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
               min={preferences.cost.min}
               name="cost"
               defaultValue={preferences.cost.max - preferences.cost.min}
-              onChange={(e)=>{setMaxRent(Number(e.target.value))}}
+              onChange={(e) => {
+                setMaxRent(Number(e.target.value));
+              }}
             />
           </div>
           <ToggleSwitch
@@ -126,7 +137,11 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
               </div>
               <Select id="roomsMin" name="roomsMin" required>
                 {preferences.propertyDetails.rooms.map((number) => {
-                  return <option key={`${number}-rooms`} value={number}>{number}</option>;
+                  return (
+                    <option key={`${number}-rooms`} value={number}>
+                      {number}
+                    </option>
+                  );
                 })}
               </Select>
             </div>
@@ -136,7 +151,11 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
               </div>
               <Select id="roomsMax" name="roomsMax" required>
                 {preferences.propertyDetails.rooms.map((number) => {
-                  return <option key={`${number}-rooms`} value={number}>{number}</option>;
+                  return (
+                    <option key={`${number}-rooms`} value={number}>
+                      {number}
+                    </option>
+                  );
                 })}
               </Select>
             </div>
@@ -147,7 +166,11 @@ const SearchPreferencesForm: FC<SearchFormProps> = ({ preferences }) => {
             </div>
             <Select id="tenancyMin" name="tenancy" required>
               {preferences.propertyDetails.tenancyMin.map((duration) => {
-                return <option key={`${duration}-duration`} value={duration}>{duration}</option>;
+                return (
+                  <option key={`${duration}-duration`} value={duration}>
+                    {duration}
+                  </option>
+                );
               })}
             </Select>
           </div>

--- a/src/utils/searchPreferenceHelpers.ts
+++ b/src/utils/searchPreferenceHelpers.ts
@@ -1,0 +1,48 @@
+import { SearchPreferenceProps } from '../../types/types';
+
+export const makeIntoQuery = (data: { [key: string]: any }) => {
+  return Object.keys(data)
+    .map((key) => {
+      let value = data[key];
+      if (value !== null && typeof value === 'object')
+        value = makeIntoQuery(value);
+      return `${key}=${value}`;
+    })
+    .join('&');
+};
+
+export const makeIntoProps = (submitted: any): SearchPreferenceProps => {
+  return {
+    preferences: {
+      location: submitted.location.value,
+      cost: {
+        max: submitted.cost.value,
+        billsIncluded: submitted.bills.checked,
+      },
+      propertyDetails: {
+        type: submitted.type.value,
+        rooms: {
+          min: submitted.roomsMin.value,
+          max: submitted.roomsMax.value,
+        },
+        tenancyMin: submitted.tenancy.value,
+      },
+      features: {
+        pets: submitted.pets_allowed.checked,
+        smokers: submitted.smokers_allowed.checked,
+        bike_storage: submitted.bike_storage.checked,
+        garden: submitted.garden.checked,
+        fireplace: submitted.fireplace.checked,
+        elevator: submitted.elevator.checked,
+        wheelchair_accessible: submitted.wheelchair_accessible.checked,
+        electric_heating: submitted.electric_heating.checked,
+        gas_heating: submitted.gas_heating.checked,
+        visitor_parking: submitted.visitor_parking.checked,
+        parking: {
+          allocated: submitted.allocated.checked,
+          exterior_parking: submitted.exterior_parking.checked,
+        },
+      },
+    },
+  };
+};

--- a/src/utils/searchPreferenceHelpers.ts
+++ b/src/utils/searchPreferenceHelpers.ts
@@ -1,5 +1,10 @@
 import { SearchPreferenceProps } from '../../types/types';
 
+/**
+ * @returns a query string from all key:value pairs in a nested Object
+ * @param data - should be the prop object received from your query to be turned into a url
+ * @remarks This function is a helper for the filter functionality or our app. It allows us to send search preferences from the SearchPreferencesForm to the /listings route
+ */
 export const makeIntoQuery = (data: { [key: string]: any }) => {
   return Object.keys(data)
     .map((key) => {
@@ -11,6 +16,11 @@ export const makeIntoQuery = (data: { [key: string]: any }) => {
     .join('&');
 };
 
+/**
+ * @returns a props object suited for the search preference functionality of our page.
+ * @remarks this function is a helper for the filter functionality in our app
+ * @param submitted should be the event.target object from your submission event.
+ */
 export const makeIntoProps = (submitted: any): SearchPreferenceProps => {
   return {
     preferences: {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -71,39 +71,6 @@ export interface SearchFormProps {
     parking: string[];
   };
 }
-export interface SearchPreferenceProps {
-  preferences: {
-    location: string;
-    cost: {
-      max: number;
-      min: number;
-      billsIncluded: boolean;
-    };
-    propertyDetails: {
-      type: string;
-      rooms: {
-        min: number;
-        max: number;
-      };
-      tenancyMin: string;
-    };
-    features: {
-      pets: boolean;
-      smokers: boolean;
-      bikeStorage: boolean;
-      garden: boolean;
-      fireplace: boolean;
-      elevator: boolean;
-      electric_heating: boolean;
-      gas_heating: boolean;
-      visitor_parking: boolean;
-      parking: {
-        allocated: boolean;
-        street: boolean;
-      };
-    };
-  };
-}
 
 export interface SearchFormProps {
   preferences: {
@@ -121,6 +88,7 @@ export interface SearchFormProps {
     parking: string[];
   };
 }
+
 export interface SearchPreferenceProps {
   preferences: {
     location: string;

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -38,19 +38,18 @@ export type PropertyType = {
 };
 
 export type StatusType = {
-  id: number,
+  id: number;
   description: string;
-}
+};
 
 export type RentRangeType = {
   min_rent: number;
   max_rent: number;
-}
+};
 
 export type Images = { id: number; url: string }[];
 export type Status = { id: number; description: string }[];
 export type Type = { id: number; description: string }[];
-
 
 export interface ContainerProps {
   listings: ListingType[];
@@ -127,11 +126,10 @@ export interface SearchPreferenceProps {
     location: string;
     cost: {
       max: number;
-      min: number;
       billsIncluded: boolean;
     };
     propertyDetails: {
-      type: string;
+      type: string[];
       rooms: {
         min: number;
         max: number;
@@ -141,10 +139,11 @@ export interface SearchPreferenceProps {
     features: {
       pets: boolean;
       smokers: boolean;
-      bikeStorage: boolean;
+      bike_storage: boolean;
       garden: boolean;
       fireplace: boolean;
       elevator: boolean;
+      wheelchair_accessible: boolean;
       electric_heating: boolean;
       gas_heating: boolean;
       visitor_parking: boolean;

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -117,7 +117,7 @@ export interface SearchPreferenceProps {
       visitor_parking: boolean;
       parking: {
         allocated: boolean;
-        street: boolean;
+        exterior_parking: boolean;
       };
     };
   };


### PR DESCRIPTION
Submitting the SearchPreferencesForm now sends all user preferences through to the '/listings' route via the URL.

Helper functions are in a new file in utils folder for better readability.

Tests added to the e2e spec checking the redirect and passing of params to the '/listings' route from '/search-preferences'
